### PR TITLE
Fix test path for cross-platform compatibility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,9 @@ def gwt_file(request):
 
 @pytest.fixture
 def target_file():
-    file = pathlib.Path(r"C:\Users\fsoza\PycharmProjects\pygwt\tests\gwt_examples\f29\new_test_1.txt")
+    """Return the sample GWT file used for parsing tests."""
+    current = pathlib.Path(__file__).parent
+    file = current / "gwt_examples" / "f29" / "new_test_1.txt"
     return file
 
 


### PR DESCRIPTION
## Summary
- fix path in `tests/conftest.py` to avoid hardcoded Windows location
- ensure tests pass on Linux

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b22ca77048332ba92d818fdd9a18a