### PR TITLE
Refactor code value lookup and fix Long type

### DIFF
--- a/pygwt/models.py
+++ b/pygwt/models.py
@@ -22,10 +22,13 @@ class BaseBuiltIn(BaseModel, metaclass=ABCMeta):
 
 class Long(BaseBuiltIn):
     """Integer encoded as base64 by GWT."""
+
     raw: str
 
     @computed_field
-    def value(self) -> float:
+    def value(self) -> int:
+        """Return the decoded integer value."""
+
         return decoder(self.raw)
 
 

--- a/pygwt/parser.py
+++ b/pygwt/parser.py
@@ -142,18 +142,15 @@ class GwtParser:
 
     def get_code_value(self, code: Any) -> Any:
         """Translate a raw *code* from ``self.codes`` into its Python value."""
-        match code:
-            case str():
-                value = code
-            case _ if code > len(self.table):
-                value = code
-            case _ if code < 0:
-                value = self.history[abs(code) - 1]
-            case 0:
-                value = None
-            case _:
-                value = self.table[code - 1]
-        return value
+        if isinstance(code, str):
+            return code
+        if code == 0:
+            return None
+        if code < 0:
+            return self.history[abs(code) - 1]
+        if code <= len(self.table):
+            return self.table[code - 1]
+        return code
 
     def parse_model_type(self, value: Any) -> type | Any:
         """Return the Python type referenced by *value* from ``self.table``."""

--- a/tests/test_get_code_value.py
+++ b/tests/test_get_code_value.py
@@ -1,0 +1,29 @@
+from pygwt.parser import GwtParser
+
+
+def _make_parser():
+    """Create a ``GwtParser`` with a minimal table for ``get_code_value`` tests."""
+
+    # Response with a single table entry ``"foo"`` and a single code ``1``.
+    text = "//OK[1,[\"foo\"],0,7]"
+    return GwtParser(text)
+
+
+def test_get_code_value_basic_cases():
+    parser = _make_parser()
+
+    # index into the table (1-based)
+    assert parser.get_code_value(1) == "foo"
+    # zero maps to ``None``
+    assert parser.get_code_value(0) is None
+    # literal strings are returned as-is
+    assert parser.get_code_value("bar") == "bar"
+    # codes greater than the table size are returned unchanged
+    assert parser.get_code_value(99) == 99
+
+
+def test_get_code_value_history_lookup():
+    parser = _make_parser()
+    parser.history.append("prev")
+    assert parser.get_code_value(-1) == "prev"
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,9 @@
+from pygwt import models
+
+
+def test_long_value_is_int():
+    """The ``Long`` wrapper should expose an integer ``value``."""
+
+    long = models.Long(raw="xV3")  # arbitrary base64 number
+    assert isinstance(long.value, int)
+


### PR DESCRIPTION
## Summary
- return integer value from `Long` built-in wrapper to match decoding behavior
- simplify `GwtParser.get_code_value` logic to avoid unnecessary comparisons
- add unit tests for `Long` wrapper and code lookup behavior
- remove leftover explanatory comments in implementation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b4eb56a2c08332a95df1c9b89681cb